### PR TITLE
Use one client struct

### DIFF
--- a/auth0/auth0.go
+++ b/auth0/auth0.go
@@ -1,31 +1,17 @@
 package auth0
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
 	"github.com/zenoss/go-auth0/auth0/authz"
+	"github.com/zenoss/go-auth0/auth0/http"
 	"github.com/zenoss/go-auth0/auth0/mgmt"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
-
-// Client can perform https requests
-type Client interface {
-	Do(req *http.Request, respBody interface{}) error
-	Get(endpoint string, respBody interface{}) error
-	Post(endpoint string, body interface{}, respBody interface{}) error
-	Put(endpoint string, body interface{}, respBody interface{}) error
-	Patch(endpoint string, body interface{}, respBody interface{}) error
-	Delete(endpoint string, body interface{}, respBody interface{}) error
-}
 
 // Config is used to create a client that uses the OAuth2 flow
 type Config struct {
@@ -39,32 +25,10 @@ type Config struct {
 
 // Auth0 is a client used to make requests to Auth0 APIs
 type Auth0 struct {
-	c     *http.Client
-	Site  string
+	*http.Client
 	Token *TokenService
 	Authz *authz.AuthorizationService
 	Mgmt  *mgmt.ManagementService
-}
-
-// Error is an an http error returned from the Auth0 service
-type Error struct {
-	StatusCode int    `json:"statusCode,omitempty"`
-	HTTPError  string `json:"error,omitempty"`
-	Message    string `json:"message,omitempty"`
-}
-
-func (e Error) Error() string {
-	msg := "auth0: "
-	if e.StatusCode != 0 {
-		msg += string(e.StatusCode) + " "
-	}
-	if e.HTTPError != "" {
-		msg += e.HTTPError + " "
-	}
-	if e.Message != "" {
-		msg += "(" + e.Message + ")"
-	}
-	return msg
 }
 
 // GrantFunc gets an Authorization Grant
@@ -103,22 +67,26 @@ func (conf *Config) ClientFromGrant(getGrant GrantFunc) (*Auth0, error) {
 		return nil, errors.Wrap(err, "Failed to exchange authorization grant for token")
 	}
 	c := &Auth0{
-		c:    cfg.Client(ctx, token),
-		Site: fmt.Sprintf("https://%s.auth0.com", conf.Tenant),
+		Client: &http.Client{
+			Doer: &http.RootClient{
+				Client: cfg.Client(ctx, token),
+			},
+			Site: fmt.Sprintf("https://%s.auth0.com", conf.Tenant),
+		},
 	}
 	c.Token = &TokenService{
-		Client: c,
+		Client: c.Client,
 	}
-	c.Mgmt = mgmt.New(c.Site, c)
+	c.Mgmt = mgmt.New(c.Site, c.Client)
 	if conf.AuthorizationURL != "" {
-		c.Authz = authz.New(conf.AuthorizationURL, c)
+		c.Authz = authz.New(conf.AuthorizationURL, c.Client)
 	}
 	return c, nil
 }
 
 // ClientFromCredentials creates a client that follows the "2-legged"
 // Client Credientials OAuth2 flow
-func (conf *Config) ClientFromCredentials(API string) (*Auth0, error) {
+func (conf *Config) ClientFromCredentials(APIs []string) (*Auth0, error) {
 	ctx := context.Background()
 	cfg := &clientcredentials.Config{
 		ClientID:     conf.ClientID,
@@ -126,132 +94,23 @@ func (conf *Config) ClientFromCredentials(API string) (*Auth0, error) {
 		TokenURL:     fmt.Sprintf("https://%s.auth0.com/oauth/token", conf.Tenant),
 		Scopes:       conf.Scopes,
 		EndpointParams: url.Values{
-			"audience": []string{API},
+			"audience": APIs,
 		},
 	}
 	c := &Auth0{
-		c:    cfg.Client(ctx),
-		Site: fmt.Sprintf("https://%s.auth0.com", conf.Tenant),
+		Client: &http.Client{
+			Doer: &http.RootClient{
+				Client: cfg.Client(ctx),
+			},
+			Site: fmt.Sprintf("https://%s.auth0.com", conf.Tenant),
+		},
 	}
 	c.Token = &TokenService{
-		Client: c,
+		Client: c.Client,
 	}
-	c.Mgmt = mgmt.New(c.Site, c)
+	c.Mgmt = mgmt.New(c.Site, c.Client)
 	if conf.AuthorizationURL != "" {
-		c.Authz = authz.New(conf.AuthorizationURL, c)
+		c.Authz = authz.New(conf.AuthorizationURL, c.Client)
 	}
 	return c, nil
-}
-
-func readAndUnmarshal(r io.Reader, obj interface{}) error {
-	data, err := ioutil.ReadAll(r)
-	if err != nil {
-		return errors.Wrap(err, "Cannot read response body")
-	}
-	fmt.Printf("Response Body:\n%s\n\n", data)
-	err = json.Unmarshal(data, obj)
-	if err != nil {
-		return errors.Wrap(err, "Cannot unmarshal response")
-	}
-	return nil
-}
-
-// Do processes a request and unmarshals the response body into respBody
-func (auth *Auth0) Do(req *http.Request, respBody interface{}) error {
-	// POSTs are application/json to this api
-	if req.ContentLength > 0 && (req.Method == "POST" ||
-		req.Method == "PUT" || req.Method == "PATCH") {
-		req.Header.Add("Content-Type", "application/json")
-	}
-	fmt.Printf("Request: %s %+v\n", req.Method, req.URL)
-	// Perform the request
-	resp, err := auth.c.Do(req)
-	if err != nil {
-		return errors.Wrap(err, "Cannot complete request")
-	}
-
-	fmt.Printf("Response Status: %s\n", resp.Status)
-	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
-		// if we have a success code and no response body, we're done
-		if resp.ContentLength == 0 {
-			return nil
-		}
-		// if we have a response body, unmarshal it
-		defer resp.Body.Close()
-		return readAndUnmarshal(resp.Body, respBody)
-	}
-	if resp.ContentLength == 0 {
-		return &Error{
-			StatusCode: resp.StatusCode,
-			HTTPError:  resp.Status,
-		}
-	}
-	var myErr Error
-	defer resp.Body.Close()
-	err = readAndUnmarshal(resp.Body, &myErr)
-	if err != nil {
-		return err
-	}
-	return myErr
-}
-
-// Get performs a get to the endpoint of the site associated with the client
-func (auth *Auth0) Get(endpoint string, respBody interface{}) error {
-	req, err := http.NewRequest("GET", auth.Site+endpoint, http.NoBody)
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return auth.Do(req, respBody)
-}
-
-// Post performs a post to the endpoint of the site associated with the client
-func (auth *Auth0) Post(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("POST", auth.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return auth.Do(req, respBody)
-}
-
-// Put performs a put to the endpoint of the site associated with the client
-func (auth *Auth0) Put(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("PUT", auth.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return auth.Do(req, respBody)
-}
-
-// Patch performs a patch to the endpoint of the site associated with the client
-func (auth *Auth0) Patch(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("PATCH", auth.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return auth.Do(req, respBody)
-}
-
-// Delete performs a delete to the endpoint of the site associated with the client
-func (auth *Auth0) Delete(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("DELETE", auth.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return auth.Do(req, respBody)
 }

--- a/auth0/authz/authz.go
+++ b/auth0/authz/authz.go
@@ -7,7 +7,6 @@ import (
 // AuthorizationService is a gateway to Auth0 Authorization Extension services
 type AuthorizationService struct {
 	*http.Client
-	Site        string
 	Groups      *GroupsService
 	Permissions *PermissionsService
 	Roles       *RolesService
@@ -18,8 +17,10 @@ type AuthorizationService struct {
 // Authorization extension lives at site
 func New(site string, client *http.Client) *AuthorizationService {
 	authz := &AuthorizationService{
-		Client: client,
-		Site:   site,
+		Client: &http.Client{
+			Doer: client,
+			Site: site,
+		},
 	}
 	authz.Groups = &GroupsService{
 		c: authz.Client,

--- a/auth0/authz/authz.go
+++ b/auth0/authz/authz.go
@@ -1,26 +1,12 @@
 package authz
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-
-	"github.com/pkg/errors"
+	http "github.com/zenoss/go-auth0/auth0/http"
 )
-
-// Client can perform https requests
-type Client interface {
-	Do(req *http.Request, respBody interface{}) error
-	Get(endpoint string, respBody interface{}) error
-	Post(endpoint string, body interface{}, respBody interface{}) error
-	Put(endpoint string, body interface{}, respBody interface{}) error
-	Patch(endpoint string, body interface{}, respBody interface{}) error
-	Delete(endpoint string, body interface{}, respBody interface{}) error
-}
 
 // AuthorizationService is a gateway to Auth0 Authorization Extension services
 type AuthorizationService struct {
-	Client
+	*http.Client
 	Site        string
 	Groups      *GroupsService
 	Permissions *PermissionsService
@@ -30,88 +16,22 @@ type AuthorizationService struct {
 
 // New creates a new AuthorizationService, backed by client, whose
 // Authorization extension lives at site
-func New(site string, client Client) *AuthorizationService {
+func New(site string, client *http.Client) *AuthorizationService {
 	authz := &AuthorizationService{
 		Client: client,
 		Site:   site,
 	}
 	authz.Groups = &GroupsService{
-		c: authz,
+		c: authz.Client,
 	}
 	authz.Permissions = &PermissionsService{
-		c: authz,
+		c: authz.Client,
 	}
 	authz.Roles = &RolesService{
-		c: authz,
+		c: authz.Client,
 	}
 	authz.Users = &UsersService{
-		c: authz,
+		c: authz.Client,
 	}
 	return authz
-}
-
-// Do processes a request and unmarshals the response body into respBody
-func (authz *AuthorizationService) Do(req *http.Request, respBody interface{}) error {
-	return authz.Client.Do(req, respBody)
-}
-
-// Get performs a get to the endpoint of the site associated with the client
-func (authz *AuthorizationService) Get(endpoint string, respBody interface{}) error {
-	req, err := http.NewRequest("GET", authz.Site+endpoint, http.NoBody)
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return authz.Do(req, respBody)
-}
-
-// Post performs a post to the endpoint of the site associated with the client
-func (authz *AuthorizationService) Post(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("POST", authz.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return authz.Do(req, respBody)
-}
-
-// Put performs a put to the endpoint of the site associated with the client
-func (authz *AuthorizationService) Put(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("PUT", authz.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return authz.Do(req, respBody)
-}
-
-// Patch performs a patch to the endpoint of the site associated with the client
-func (authz *AuthorizationService) Patch(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("PATCH", authz.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return authz.Do(req, respBody)
-}
-
-// Delete performs a delete to the endpoint of the site associated with the client
-func (authz *AuthorizationService) Delete(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("DELETE", authz.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return authz.Do(req, respBody)
 }

--- a/auth0/authz/authz_test.go
+++ b/auth0/authz/authz_test.go
@@ -23,7 +23,7 @@ func (s *AuthzTestSuite) SetupSuite() {
 		Tenant:           os.Getenv("AUTH0_TENANT"),
 		AuthorizationURL: os.Getenv("AUTH0_AUTHORIZATION_URL"),
 	}
-	client, err := cfg.ClientFromCredentials(os.Getenv("AUTH0_AUTHORIZATION_API"))
+	client, err := cfg.ClientFromCredentials([]string{os.Getenv("AUTH0_AUTHORIZATION_API")})
 	assert.Nil(s.T(), err)
 	s.Client = client
 }

--- a/auth0/authz/groups.go
+++ b/auth0/authz/groups.go
@@ -1,10 +1,14 @@
 package authz
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+	"github.com/zenoss/go-auth0/auth0/http"
+	"github.com/zenoss/go-auth0/auth0/mgmt"
+)
 
 // GroupsService provides a service for group related functions
 type GroupsService struct {
-	c Client
+	c *http.Client
 }
 
 // GroupStub is a stub of a group
@@ -27,6 +31,11 @@ type Mapping struct {
 	ID             string `json:"_id,omitempty"`
 	GroupName      string `json:"groupName,omitempty"`
 	ConnectionName string `json:"connectionName,omitempty"`
+}
+
+type Members struct {
+	Total int         `json:"total,omitempty"`
+	Users []mgmt.User `json:"users,omitempty"`
 }
 
 // GetAll returns all groups
@@ -97,8 +106,8 @@ func (svc *GroupsService) DeleteMappings(groupID string, mappings []Mapping) ([]
 }
 
 // GetMembers gets the members of a group
-func (svc *GroupsService) GetMembers(groupID string) ([]string, error) {
-	var members []string
+func (svc *GroupsService) GetMembers(groupID string) (Members, error) {
+	var members Members
 	err := svc.c.Get("/api/groups/"+groupID+"/members", &members)
 	return members, err
 }

--- a/auth0/authz/groups.go
+++ b/auth0/authz/groups.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"github.com/pkg/errors"
 	"github.com/zenoss/go-auth0/auth0/http"
-	"github.com/zenoss/go-auth0/auth0/mgmt"
 )
 
 // GroupsService provides a service for group related functions
@@ -31,11 +30,6 @@ type Mapping struct {
 	ID             string `json:"_id,omitempty"`
 	GroupName      string `json:"groupName,omitempty"`
 	ConnectionName string `json:"connectionName,omitempty"`
-}
-
-type Members struct {
-	Total int         `json:"total,omitempty"`
-	Users []mgmt.User `json:"users,omitempty"`
 }
 
 // GetAll returns all groups
@@ -106,8 +100,8 @@ func (svc *GroupsService) DeleteMappings(groupID string, mappings []Mapping) ([]
 }
 
 // GetMembers gets the members of a group
-func (svc *GroupsService) GetMembers(groupID string) (Members, error) {
-	var members Members
+func (svc *GroupsService) GetMembers(groupID string) ([]string, error) {
+	var members []string
 	err := svc.c.Get("/api/groups/"+groupID+"/members", &members)
 	return members, err
 }

--- a/auth0/authz/permissions.go
+++ b/auth0/authz/permissions.go
@@ -1,8 +1,12 @@
 package authz
 
+import (
+	"github.com/zenoss/go-auth0/auth0/http"
+)
+
 // PermissionsService provides a service for permission related functions
 type PermissionsService struct {
-	c Client
+	c *http.Client
 }
 
 // Permission is a permission

--- a/auth0/authz/roles.go
+++ b/auth0/authz/roles.go
@@ -1,8 +1,12 @@
 package authz
 
+import (
+	"github.com/zenoss/go-auth0/auth0/http"
+)
+
 // RolesService provides a service for role related functions
 type RolesService struct {
-	c Client
+	c *http.Client
 }
 
 // Role is a role

--- a/auth0/authz/users.go
+++ b/auth0/authz/users.go
@@ -1,10 +1,13 @@
 package authz
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+	"github.com/zenoss/go-auth0/auth0/http"
+)
 
 // UsersService provides a service for user related functions
 type UsersService struct {
-	c Client
+	c *http.Client
 }
 
 // User is a user

--- a/auth0/http/client.go
+++ b/auth0/http/client.go
@@ -3,7 +3,6 @@ package http
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -32,7 +31,6 @@ func readAndUnmarshal(r io.Reader, obj interface{}) error {
 	if err != nil {
 		return errors.Wrap(err, "Cannot read response body")
 	}
-	fmt.Printf("Response Body:\n%s\n\n", data)
 	err = json.Unmarshal(data, obj)
 	if err != nil {
 		return errors.Wrap(err, "Cannot unmarshal response")

--- a/auth0/http/client.go
+++ b/auth0/http/client.go
@@ -1,0 +1,148 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// Doer can do http requests
+type Doer interface {
+	Do(*http.Request, interface{}) error
+}
+
+// Client handles requests to Site
+type Client struct {
+	Doer
+	Site string
+}
+
+// RootClient is composed of an actual http.Client that makes the requests
+type RootClient struct {
+	*http.Client
+}
+
+func readAndUnmarshal(r io.Reader, obj interface{}) error {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return errors.Wrap(err, "Cannot read response body")
+	}
+	fmt.Printf("Response Body:\n%s\n\n", data)
+	err = json.Unmarshal(data, obj)
+	if err != nil {
+		return errors.Wrap(err, "Cannot unmarshal response")
+	}
+	return nil
+}
+
+func getResponseError(resp *http.Response) error {
+	if resp.ContentLength == 0 {
+		return &Error{
+			StatusCode: resp.StatusCode,
+			HTTPError:  resp.Status,
+		}
+	}
+	var respError Error
+	defer resp.Body.Close()
+	err := readAndUnmarshal(resp.Body, &respError)
+	if err != nil {
+		return err
+	}
+	return respError
+}
+
+// Do processes a request and unmarshals the response body into respBody
+func (c *RootClient) Do(req *http.Request, respBody interface{}) error {
+	// POSTs are application/json to this api
+	if req.ContentLength > 0 && (req.Method == "POST" ||
+		req.Method == "PUT" || req.Method == "PATCH") {
+		req.Header.Add("Content-Type", "application/json")
+	}
+	// Perform the request
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "Cannot complete request")
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		// if we have a success code and no response body, we're done
+		if resp.ContentLength == 0 {
+			return nil
+		}
+		// if we have a response body, unmarshal it
+		defer resp.Body.Close()
+		return readAndUnmarshal(resp.Body, respBody)
+	}
+	return getResponseError(resp)
+}
+
+// Do processes a request and unmarshals the response body into respBody
+func (c *Client) Do(req *http.Request, respBody interface{}) error {
+	return c.Doer.Do(req, respBody)
+}
+
+// Get performs a get to the endpoint of the site associated with the client
+func (c *Client) Get(endpoint string, respBody interface{}) error {
+	req, err := http.NewRequest("GET", c.Site+endpoint, http.NoBody)
+	if err != nil {
+		return errors.Wrap(err, "Cannot create request")
+	}
+	return c.Doer.Do(req, respBody)
+}
+
+// Post performs a post to the endpoint of the site associated with the client
+func (c *Client) Post(endpoint string, body interface{}, respBody interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return errors.Wrap(err, "Cannot marshal body")
+	}
+	req, err := http.NewRequest("POST", c.Site+endpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return errors.Wrap(err, "Cannot create request")
+	}
+	return c.Doer.Do(req, respBody)
+}
+
+// Put performs a put to the endpoint of the site associated with the client
+func (c *Client) Put(endpoint string, body interface{}, respBody interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return errors.Wrap(err, "Cannot marshal body")
+	}
+	req, err := http.NewRequest("PUT", c.Site+endpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return errors.Wrap(err, "Cannot create request")
+	}
+	return c.Doer.Do(req, respBody)
+}
+
+// Patch performs a patch to the endpoint of the site associated with the client
+func (c *Client) Patch(endpoint string, body interface{}, respBody interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return errors.Wrap(err, "Cannot marshal body")
+	}
+	req, err := http.NewRequest("PATCH", c.Site+endpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return errors.Wrap(err, "Cannot create request")
+	}
+	return c.Doer.Do(req, respBody)
+}
+
+// Delete performs a delete to the endpoint of the site associated with the client
+func (c *Client) Delete(endpoint string, body interface{}, respBody interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return errors.Wrap(err, "Cannot marshal body")
+	}
+	req, err := http.NewRequest("DELETE", c.Site+endpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return errors.Wrap(err, "Cannot create request")
+	}
+	return c.Doer.Do(req, respBody)
+}

--- a/auth0/http/errors.go
+++ b/auth0/http/errors.go
@@ -1,0 +1,22 @@
+package http
+
+// Error is an an http error returned from the Auth0 service
+type Error struct {
+	StatusCode int    `json:"statusCode,omitempty"`
+	HTTPError  string `json:"error,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+func (e Error) Error() string {
+	msg := "auth0: "
+	if e.StatusCode != 0 {
+		msg += string(e.StatusCode) + " "
+	}
+	if e.HTTPError != "" {
+		msg += e.HTTPError + " "
+	}
+	if e.Message != "" {
+		msg += "(" + e.Message + ")"
+	}
+	return msg
+}

--- a/auth0/mgmt/mgmt.go
+++ b/auth0/mgmt/mgmt.go
@@ -1,104 +1,24 @@
 package mgmt
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-
-	"github.com/pkg/errors"
+	"github.com/zenoss/go-auth0/auth0/http"
 )
-
-// Client can perform https requests
-type Client interface {
-	Do(req *http.Request, respBody interface{}) error
-	Get(endpoint string, respBody interface{}) error
-	Post(endpoint string, body interface{}, respBody interface{}) error
-	Put(endpoint string, body interface{}, respBody interface{}) error
-	Patch(endpoint string, body interface{}, respBody interface{}) error
-	Delete(endpoint string, body interface{}, respBody interface{}) error
-}
 
 // ManagementService is a gateway to Auth0 Management services
 type ManagementService struct {
-	Client
+	*http.Client
 	Site  string
 	Users *UsersService
 }
 
 // New creates a new ManagementService, backed by client
-func New(site string, client Client) *ManagementService {
+func New(site string, client *http.Client) *ManagementService {
 	mgmt := &ManagementService{
 		Client: client,
 		Site:   site,
 	}
 	mgmt.Users = &UsersService{
-		c: mgmt,
+		c: mgmt.Client,
 	}
 	return mgmt
-}
-
-// Do processes a request and unmarshals the response body into respBody
-func (mgmt *ManagementService) Do(req *http.Request, respBody interface{}) error {
-	return mgmt.Client.Do(req, respBody)
-}
-
-// Get performs a get to the endpoint of the site associated with the client
-func (mgmt *ManagementService) Get(endpoint string, respBody interface{}) error {
-	req, err := http.NewRequest("GET", mgmt.Site+endpoint, http.NoBody)
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return mgmt.Do(req, respBody)
-}
-
-// Post performs a post to the endpoint of the site associated with the client
-func (mgmt *ManagementService) Post(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("POST", mgmt.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return mgmt.Do(req, respBody)
-}
-
-// Put performs a put to the endpoint of the site associated with the client
-func (mgmt *ManagementService) Put(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("PUT", mgmt.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return mgmt.Do(req, respBody)
-}
-
-// Patch performs a patch to the endpoint of the site associated with the client
-func (mgmt *ManagementService) Patch(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("PATCH", mgmt.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return mgmt.Do(req, respBody)
-}
-
-// Delete performs a delete to the endpoint of the site associated with the client
-func (mgmt *ManagementService) Delete(endpoint string, body interface{}, respBody interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return errors.Wrap(err, "Cannot marshal body")
-	}
-	req, err := http.NewRequest("DELETE", mgmt.Site+endpoint, bytes.NewBuffer(data))
-	if err != nil {
-		return errors.Wrap(err, "Cannot create request")
-	}
-	return mgmt.Do(req, respBody)
 }

--- a/auth0/mgmt/mgmt.go
+++ b/auth0/mgmt/mgmt.go
@@ -7,15 +7,16 @@ import (
 // ManagementService is a gateway to Auth0 Management services
 type ManagementService struct {
 	*http.Client
-	Site  string
 	Users *UsersService
 }
 
 // New creates a new ManagementService, backed by client
 func New(site string, client *http.Client) *ManagementService {
 	mgmt := &ManagementService{
-		Client: client,
-		Site:   site,
+		Client: &http.Client{
+			Doer: client,
+			Site: site,
+		},
 	}
 	mgmt.Users = &UsersService{
 		c: mgmt.Client,

--- a/auth0/mgmt/mgmt_test.go
+++ b/auth0/mgmt/mgmt_test.go
@@ -23,7 +23,7 @@ func (s *ManagementTestSuite) SetupSuite() {
 		Tenant:           os.Getenv("AUTH0_TENANT"),
 		AuthorizationURL: os.Getenv("AUTH0_AUTHORIZATION_URL"),
 	}
-	client, err := cfg.ClientFromCredentials(os.Getenv("AUTH0_MANAGEMENT_API"))
+	client, err := cfg.ClientFromCredentials([]string{os.Getenv("AUTH0_MANAGEMENT_API")})
 	assert.Nil(s.T(), err)
 	s.Client = client
 }

--- a/auth0/mgmt/users.go
+++ b/auth0/mgmt/users.go
@@ -1,8 +1,12 @@
 package mgmt
 
+import (
+	"github.com/zenoss/go-auth0/auth0/http"
+)
+
 // UsersService provides a service for user related functions
 type UsersService struct {
-	c Client
+	c *http.Client
 }
 
 // User is a user in Auth0

--- a/auth0/token.go
+++ b/auth0/token.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
+	"github.com/zenoss/go-auth0/auth0/http"
 )
 
 // TokenService provides a service for token related functions
 type TokenService struct {
-	Client
+	*http.Client
 	API string
 }
 


### PR DESCRIPTION
Previously, every service had it's own client definition, but that is unncesessary.
We can use a single client which can be inherited by all sub-services, backed by a single real http.Client.

Also, allow a slice for APIs, since access to multiple apis can be requested.