### PR TITLE
Add option to include body in Delete call

### DIFF
--- a/auth0/mgmt/users.go
+++ b/auth0/mgmt/users.go
@@ -142,6 +142,10 @@ func (svc *UsersService) Delete(userID string) error {
 	return svc.c.Delete("/users/"+userID, nil, nil)
 }
 
+func (svc *UsersService) DeleteWithBody(userID string, body interface{}) error {
+	return svc.c.Delete("/users/"+userID, &body, nil)
+}
+
 // Update updates a user
 func (svc *UsersService) Update(userID string, opts UserUpdateOpts) (User, error) {
 	var user User


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZING-2715

Add an optional body argument to the Auth0 Delete call.  This allows us to pass an arbitrary body to Auth0 to help with debugging and tracking user deletion (necessary in the api key management service).

{
  "method": "delete",
  "path": "/api/v2/users/auth0%7Ce30d5fxakukif2k974wpm0lys",
  "query": {},
  "userAgent": "Go-http-client/2.0",
  "body": {
    "user": "rphillips@zenoss.com",
    "tenant": "ronp"
  },
  "channel": "api",
  "ip": "66.55.33.66",
  "auth": {
    "user": {},
    "strategy": "jwt",
    "credentials": {
      "scopes": [
...`